### PR TITLE
add a tactic _INST_TYPE_RENAME 

### DIFF
--- a/lisa-hol/src/main/scala/lisa/hol/ExtendedHOLSteps.scala
+++ b/lisa-hol/src/main/scala/lisa/hol/ExtendedHOLSteps.scala
@@ -1,0 +1,74 @@
+package lisa.hol
+import lisa.SetTheoryLibrary
+import lisa.automation._
+import lisa.hol.VarsAndFunctions._
+import lisa.maths.SetTheory.Base.Predef.∈
+import lisa.maths.SetTheory.Functions.Predef.{_, given}
+import lisa.maths.SetTheory.Types
+import lisa.maths.SetTheory.Types.Tactics.Typecheck
+import lisa.utils.K
+import lisa.utils.UserLisaException
+import lisa.utils.fol.FOL._
+import lisa.utils.prooflib.BasicStepTactic._
+import lisa.utils.prooflib.ProofTacticLib.ProofTactic
+import scala.collection.mutable
+
+import SetTheoryLibrary.{have, JUSTIFICATION, thesis, THM, Proof, Theorem}
+import lisa.utils.prooflib.BasicStepTactic.Weakening
+
+import lisa.hol.Import.mkTypedVar
+
+
+object ExtendedHOLSteps {
+
+  import lisa.hol.HOLHelperTheorems.{One, nonEmptyFuncSpace, assume, eqRefl}
+  import K.repr
+  
+
+
+  object _INST_TYPE_RENAME extends ProofTactic {
+    def allTypedVars(e: Expr[?]): Set[(TypedVariable, Expr[Ind])] = e match
+      case v: TypedVariable => Set((v, v.typ))
+      case App(func, arg) => allTypedVars(func) ++ allTypedVars(arg)
+      case Abs(v: TypedVariable, body) =>
+        allTypedVars(body) + ((v, v.typ): (TypedVariable, Expr[Ind]))
+      case Abs(v, body) => allTypedVars(v) ++ allTypedVars(body)
+      case _ => Set.empty
+
+    def variableTypesNames(using proof: Proof)(prem: proof.Fact): proof.ProofTacticJudgement = TacticSubproof { ip ?=>
+      val variablesSubst : mutable.Map[Variable[Ind], Variable[Ind]] = mutable.Map.empty
+      val allvars = prem.statement.left.flatMap(allTypedVars) ++ prem.statement.right.flatMap(allTypedVars)
+      val varsToChange: Map[Variable[Ind], TypedVariable] = 
+        allvars.collect { case (v, typ) if v.id.no != typ.hashCode().abs => (v, mkTypedVar(v.id.name, typ)) }.toMap
+
+      def changeVarInExpr[A](e: Expr[A]): Expr[A] = e match
+        case v: Variable[?] =>
+          varsToChange.toMap.getOrElse(v, v).asInstanceOf[Variable[A]]
+        case Abs(v: Variable[?], body) =>
+          val targetVar = varsToChange.toMap.getOrElse(v, v)
+          val targetBody = changeVarInExpr(body) 
+          if (targetVar eq v) && (targetBody eq body) then e else
+          Abs(targetVar, targetBody).asInstanceOf[Expr[A]]
+        case App(func, arg) =>
+          val targetFunc = changeVarInExpr(func)
+          val targetArg = changeVarInExpr(arg)
+          if (targetFunc eq func ) && (targetArg eq arg) then e else
+          App(targetFunc, targetArg)
+        case cst: Constant[A] => cst
+      val targetSequent = prem.statement.left.map(changeVarInExpr) |- prem.statement.right.map(changeVarInExpr)
+      val instPrem = prem.of( (varsToChange.map { case (from, to) => from := to}).toSeq* )
+      have(targetSequent) by Restate.from(instPrem)
+    }
+
+    def apply(using proof: Proof)(inst: Seq[(Variable[Ind], Expr[Ind])], prem: proof.Fact): proof.ProofTacticJudgement = TacticSubproof { ip ?=>
+      val s1 = have(lisa.hol.HOLSteps._INST_TYPE(inst, prem))
+      have(variableTypesNames(s1))
+    }
+
+  }
+}
+
+/*
+prelForm.underlying:    app(app(=:=(Pi(Pi(A)(lambda(x, B)))(lambda(x, 𝔹))))(app(=:=(Pi(A)(lambda(x, B))))(z)))(app(abs(Pi(A)(lambda(x, B)))(lambda(x, abs(Pi(A)(lambda(x, B)))(lambda(y, app(app(=:=(Pi(A)(lambda(x, B))))(x))(y))))))(z)) === One
+targetForm.underlying:  app(app(=:=(Pi(Pi(A)(lambda(x_196788543, B)))(lambda(x_196788543, 𝔹))))(app(=:=(Pi(A)(lambda(x_196788543, B))))(z_196788543)))(app(abs(Pi(A)(lambda(x_196788543, B)))(lambda(x_196788543, abs(Pi(A)(lambda(x_196788543, B)))(lambda(y_196788543, app(app(=:=(Pi(A)(lambda(x_196788543, B))))(x_196788543))(y_196788543))))))(z_196788543)) === One
+*/

--- a/lisa-hol/src/main/scala/lisa/hol/HOLExtStepsTests.scala
+++ b/lisa-hol/src/main/scala/lisa/hol/HOLExtStepsTests.scala
@@ -1,0 +1,109 @@
+package lisa.hol
+
+import lisa.automation.Substitution.{Apply => Substitute}
+import lisa.hol.HOLHelperTheorems._
+import lisa.hol.HOLSteps._
+import lisa.hol.VarsAndFunctions._
+import lisa.maths.SetTheory.Base.Pair.given
+import lisa.maths.SetTheory.Base.Replacement.|
+import lisa.maths.SetTheory.Types.Tactics.Typecheck
+import lisa.maths.SetTheory.Types.TypingRules.BetaReduction
+import lisa.maths.SetTheory.Types.TypingRules.TAbs
+import lisa.utils.prooflib.BasicStepTactic._
+import lisa.utils.prooflib.Library
+import lisa.utils.prooflib.ProofTacticLib._
+import lisa.utils.prooflib.SimpleDeducedSteps._
+import lisa.utils.unification.UnificationUtils.Substitution
+import lisa.utils.prooflib.BasicStepTactic.RightSubstEq
+import lisa.utils.prooflib.BasicStepTactic.Restate
+import lisa.utils.prooflib.BasicStepTactic.RightAnd
+import lisa.utils.prooflib.BasicStepTactic.Weakening
+import lisa.utils.prooflib.BasicStepTactic.RightSubstEq
+import lisa.utils.prooflib.BasicStepTactic.Weakening
+import lisa.utils.unification.UnificationUtils.Substitution
+import lisa.utils.prooflib.BasicStepTactic.RightSubstEq
+import lisa.utils.prooflib.SimpleDeducedSteps.Discharge
+import lisa.utils.unification.UnificationUtils.Substitution
+import lisa.utils.prooflib.BasicStepTactic.LeftSubstEq
+
+import lisa.hol.ExtendedHOLSteps._INST_TYPE_RENAME
+import lisa.hol.Import.mkTypedVar
+
+import lisa.hol.HOLBasics.{SYM}
+
+object HOLExtStepsTests extends lisa.HOL {
+  draft()
+
+  val A = typevar
+  val B = typevar
+  val T = typevar
+
+  val x = typedvar(A)
+  val y = typedvar(A)
+  val z = typedvar(A)
+  val P = typedvar(A ->: 𝔹)
+
+  val f = typedvar(A ->: B)
+  val g = typedvar(A ->: B)
+
+  val p = typedvar(𝔹)
+  val q = typedvar(𝔹)
+
+  val φ = variable[Prop]
+
+  val lib = summon[Library]
+
+
+  val holeqBetaReduced = HOLTheorem(
+    holeq(A) =:= fun(x, fun(y, x =:= y))
+  ):
+    SYM(TRANS(
+      ABS(x)( // fun(x, fun(y, x =:= y)) =:= fun(x, holeq(A) * x)
+        ETA(y, holeq(A) * x) // fun(y, holeq(A) * x * y) =:= holeq(A) * x
+      ),
+      ETA(x, holeq(A)) // fun(x, holeq(A) * x) =:= holeq(A)
+    ))
+
+  val holeqBetaReducedFull = HOLTheorem(
+    holeq(A)*z*z =:= fun(x, fun(y, x =:= y))*z*z
+  ):
+    sorry
+
+
+
+
+  val xb = mkTypedVar("x", B)
+  val yb = mkTypedVar("y", B)
+  val instTypeTest1 = HOLTheorem(
+    holeq(B) =:= fun(xb, fun(yb, xb =:= yb))
+  ):
+    have(_INST_TYPE_RENAME(Seq((A, B)), holeqBetaReduced))
+
+
+
+  val xba = mkTypedVar("x", A ->: B)
+  val yba = mkTypedVar("y", A ->: B)
+  val instTypeTest2 = HOLTheorem(
+    holeq(A ->: B) =:= fun(xba, fun(yba, xba =:= yba))
+  ):
+    have(_INST_TYPE_RENAME(Seq((A, A ->: B)), holeqBetaReduced))
+
+
+
+  val fba = mkTypedVar("f", A ->: B)
+  val zba = mkTypedVar("z", A ->: B)
+  val instTypeTest3 = HOLTheorem(
+    (holeq(A ->: B)*zba*zba) =:= (fun(xba, fun(yba, xba =:= yba))*zba*zba)
+  ):
+    val s1 = have(_INST_TYPE_RENAME(Seq((A, A ->: B)), holeqBetaReducedFull))
+
+
+
+
+  val instTypeTest4 = HOLTheorem(
+    (holeq(A ->: B)*fba*fba) =:= (fun(xba, fun(yba, xba =:= yba))*fba*fba)
+  ):
+    val s1 = have(_INST_TYPE_RENAME(Seq((A, A ->: B)), holeqBetaReducedFull))
+    have(_INST(Seq((zba, fba)), s1))
+
+}

--- a/lisa-hol/src/main/scala/lisa/hol/Import.scala
+++ b/lisa-hol/src/main/scala/lisa/hol/Import.scala
@@ -50,7 +50,10 @@ object Import extends lisa.HOL:
   import Logging.*
   private var currentLoggingMode: LoggingMode = LoggingMode.Silent
   given LoggingMode = currentLoggingMode
-
+  def mkTypedVar(name: String, tpe: Expr[Ind]): TypedVariable =
+      // unfortunate to double the clashes, but identifier indices are
+      // expected to be positive
+    TypedVariable(K.Identifier(name, tpe.hashCode().abs), tpe)
   private object Transformers:
     
     extension (typ: h.Type) 
@@ -73,13 +76,12 @@ object Import extends lisa.HOL:
               // this is runtime checked wherever used
               (typeConstant #@@ typeArgs).asInstanceOf
 
+    
+
     extension (v: h.Variable)
       def toLisaVar : TypedVariable =
         val tpe = v.tpe.toLisaType
-        // unfortunate to double the clashes, but identifier indices are
-        // expected to be positive
-        val name = K.Identifier(v.name, v.tpe.hashCode().abs)
-        TypedVariable(name, tpe)
+        mkTypedVar(name, tpe)
 
     extension (v: h.TypeVariable)
       def toLisaVar : TypeVariable =

--- a/lisa-sets/src/main/scala/lisa/maths/SetTheory/Relations/WellFoundedRelation.scala
+++ b/lisa-sets/src/main/scala/lisa/maths/SetTheory/Relations/WellFoundedRelation.scala
@@ -1,6 +1,6 @@
 package lisa.maths.SetTheory.Relations
 
-import lisa.maths.SetTheory.Base.Predef._
+import lisa.maths.SetTheory.Base.Predef.{_, given}
 import lisa.maths.SetTheory.Functions.Predef._
 import lisa.maths.SetTheory.Order.Extrema.minimal
 


### PR DESCRIPTION
add a tactic _INST_TYPE_RENAME that rename variable symbols to maintain invariants that variables ids are unique per types.

I've tested it with a couple examples and it seems to be working.